### PR TITLE
fix: template update bug

### DIFF
--- a/internal/provider/resource_template.go
+++ b/internal/provider/resource_template.go
@@ -193,12 +193,6 @@ func publishTemplate(ctx context.Context, d *schema.ResourceData, client *sp.Cli
 		if err != nil {
 			return err
 		}
-
-		// ensure the read looks for published templates
-		d.Set("draft", false)
-	} else {
-		// ensure the read looks for draft templates
-		d.Set("draft", true)
 	}
 
 	return nil
@@ -220,6 +214,9 @@ func resourceTemplateCreate(ctx context.Context, d *schema.ResourceData, m inter
 	if err != nil {
 		return diag.FromErr(err)
 	}
+
+	// Ensure the read looks for the correct copy of the template
+	d.Set("draft", !template.Published)
 
 	d.SetId(id)
 
@@ -262,6 +259,9 @@ func resourceTemplateUpdate(ctx context.Context, d *schema.ResourceData, m inter
 	if err != nil {
 		return diag.FromErr(err)
 	}
+
+	// Ensure the read looks for the correct copy of the template
+	d.Set("draft", !published)
 
 	return resourceTemplateRead(ctx, d, m)
 }

--- a/internal/provider/resource_template.go
+++ b/internal/provider/resource_template.go
@@ -186,13 +186,11 @@ func buildTemplate(templateID string, d *schema.ResourceData) *sp.Template {
 	return template
 }
 
-func publishTemplate(ctx context.Context, d *schema.ResourceData, client *sp.Client, templateID string, publish bool) error {
-	if publish {
-		// automatically publish the template
-		_, err := client.TemplatePublishContext(ctx, templateID)
-		if err != nil {
-			return err
-		}
+func publishTemplate(ctx context.Context, d *schema.ResourceData, client *sp.Client, templateID string) error {
+	// automatically publish the template
+	_, err := client.TemplatePublishContext(ctx, templateID)
+	if err != nil {
+		return err
 	}
 
 	return nil
@@ -210,9 +208,11 @@ func resourceTemplateCreate(ctx context.Context, d *schema.ResourceData, m inter
 		return diag.FromErr(err)
 	}
 
-	err = publishTemplate(ctx, d, client, templateID, template.Published)
-	if err != nil {
-		return diag.FromErr(err)
+	if template.Published {
+		err = publishTemplate(ctx, d, client, templateID)
+		if err != nil {
+			return diag.FromErr(err)
+		}
 	}
 
 	// Ensure the read looks for the correct copy of the template
@@ -255,9 +255,11 @@ func resourceTemplateUpdate(ctx context.Context, d *schema.ResourceData, m inter
 	}
 
 	// Publish it if we're going from draft -> published
-	err = publishTemplate(ctx, d, client, templateID, publishUpdate)
-	if err != nil {
-		return diag.FromErr(err)
+	if publishUpdate {
+		err = publishTemplate(ctx, d, client, templateID)
+		if err != nil {
+			return diag.FromErr(err)
+		}
 	}
 
 	// Ensure the read looks for the correct copy of the template


### PR DESCRIPTION
This PR fixes two bugs relating to template updates.

<details>
<summary>Problem #1: incorrect template version modified during an update</summary>


Consider a template resource whose state has changed from `published=false` to `published=true`. The intent of `resourceTemplateUpdate()` is to do this:

1. update the draft
1. publish the draft
1. read the published copy

However, due to some very unusual behavior of the Sparkpost API (see [comment here](https://github.com/SurveyMonkey/terraform-provider-sparkpost/blob/b77a71708c760134f32f074fa58e9795e62c8b95/internal/provider/resource_template.go#L241-L244)), it was actually doing this:

1. update the published copy :warning:
1. publish the draft
1. read the published copy

This essentially results in a no-op, as the unmodified draft overwrites the published version.

</details>


<details>
<summary>Problem #2: incorrect template version fetched after an update</summary>


Consider a template resource that has previously been published, and whose `content_html` field has been updated. Within `resourceTemplateUpdate()`,the incoming ResourceData state will be:

| Expression                       | Value   |
|----------------------------------|---------|
| `d.Get("published").(bool)`      | `true`  |
| `d.HasChange("published")`       | `false` |

… And accordingly the variables will be set as follows:

| Variable                          | Value  |
|-----------------------------------|--------|
| `published`                       | `true` |
| `publishUpdate`                   | `false`|
| `updatePublished`                 | `true` |

With such a setup, `publishTemplate()`skips publishing the draft (good), but then decides to read the draft copy at the end, because `updatePublished` is `false`. This is wrong, and results in the draft copy being incorrectly persisted into the tfstate file.

Subsequent plans will therefore incorrectly flag the template as having changed from `published=false` to `published=true`, which causes superfluous changes.

</details>

------------

Taking 1 and 2 together:

- odd deploys update SparkPost correctly, but corrupt the tfstate
- even deploys fail to update SparkPost, but correctly persist the tfstate

Every deploy, therefore, would show an outgoing change in the plan, and only half the deploys put SparkPost into the correct state.
